### PR TITLE
Update the advanced style file used for roads layer

### DIFF
--- a/exercise_data/styles/advanced_levels_demo.qml
+++ b/exercise_data/styles/advanced_levels_demo.qml
@@ -1,124 +1,225 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis version="2.0.1-Dufour" minimumScale="-4.65661e-10" maximumScale="1e+08" minLabelScale="1" maxLabelScale="1e+08" hasScaleBasedVisibilityFlag="0" scaleBasedLabelVisibilityFlag="0">
-  <renderer-v2 attr="highway" symbollevels="0" type="categorizedSymbol">
+<qgis simplifyLocal="1" styleCategories="AllStyleCategories" simplifyDrawingTol="1" simplifyMaxScale="1" labelsEnabled="0" maxScale="-4.65661e-10" simplifyAlgorithm="0" hasScaleBasedVisibilityFlag="0" minScale="1e+8" simplifyDrawingHints="1" version="3.4.3-Madeira" readOnly="0">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+  </flags>
+  <renderer-v2 enableorderby="0" type="categorizedSymbol" attr="highway" forceraster="0" symbollevels="1">
     <categories>
-      <category symbol="0" value="tertiary" label="tertiary"/>
-      <category symbol="1" value="trunk" label="trunk"/>
-      <category symbol="2" value="unclassified" label="unclassified"/>
+      <category value="trunk" render="true" symbol="0" label="Trunk"/>
+      <category value="tertiary" render="true" symbol="1" label="Tertiary"/>
+      <category value="" render="true" symbol="2" label="Unclassified"/>
     </categories>
     <symbols>
-      <symbol alpha="1" type="line" name="0">
-        <layer pass="1" class="SimpleLine" locked="1">
+      <symbol alpha="1" type="line" clip_to_extent="1" force_rhr="0" name="0">
+        <layer pass="1" enabled="1" class="SimpleLine" locked="1">
           <prop k="capstyle" v="square"/>
-          <prop k="color" v="0,0,0,255"/>
           <prop k="customdash" v="5;2"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="customdash_unit" v="MM"/>
+          <prop k="draw_inside_polygon" v="0"/>
           <prop k="joinstyle" v="bevel"/>
+          <prop k="line_color" v="0,0,0,255"/>
+          <prop k="line_style" v="solid"/>
+          <prop k="line_width" v="5"/>
+          <prop k="line_width_unit" v="MM"/>
           <prop k="offset" v="0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="offset_unit" v="MM"/>
-          <prop k="penstyle" v="solid"/>
+          <prop k="ring_filter" v="0"/>
           <prop k="use_custom_dash" v="0"/>
-          <prop k="width" v="2"/>
-          <prop k="width_unit" v="MM"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
         </layer>
-        <layer pass="2" class="SimpleLine" locked="0">
+        <layer pass="3" enabled="1" class="SimpleLine" locked="0">
           <prop k="capstyle" v="square"/>
-          <prop k="color" v="255,222,155,255"/>
           <prop k="customdash" v="5;2"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="customdash_unit" v="MM"/>
+          <prop k="draw_inside_polygon" v="0"/>
           <prop k="joinstyle" v="bevel"/>
+          <prop k="line_color" v="255,155,105,255"/>
+          <prop k="line_style" v="solid"/>
+          <prop k="line_width" v="3"/>
+          <prop k="line_width_unit" v="MM"/>
           <prop k="offset" v="0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="offset_unit" v="MM"/>
-          <prop k="penstyle" v="solid"/>
+          <prop k="ring_filter" v="0"/>
           <prop k="use_custom_dash" v="0"/>
-          <prop k="width" v="1.2"/>
-          <prop k="width_unit" v="MM"/>
-        </layer>
-      </symbol>
-      <symbol alpha="1" type="line" name="1">
-        <layer pass="1" class="SimpleLine" locked="1">
-          <prop k="capstyle" v="square"/>
-          <prop k="color" v="0,0,0,255"/>
-          <prop k="customdash" v="5;2"/>
-          <prop k="customdash_unit" v="MM"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="offset" v="0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="penstyle" v="solid"/>
-          <prop k="use_custom_dash" v="0"/>
-          <prop k="width" v="5"/>
-          <prop k="width_unit" v="MM"/>
-        </layer>
-        <layer pass="3" class="SimpleLine" locked="0">
-          <prop k="capstyle" v="square"/>
-          <prop k="color" v="255,155,105,255"/>
-          <prop k="customdash" v="5;2"/>
-          <prop k="customdash_unit" v="MM"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="offset" v="0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="penstyle" v="solid"/>
-          <prop k="use_custom_dash" v="0"/>
-          <prop k="width" v="3"/>
-          <prop k="width_unit" v="MM"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
         </layer>
       </symbol>
-      <symbol alpha="1" type="line" name="2">
-        <layer pass="0" class="SimpleLine" locked="0">
+      <symbol alpha="1" type="line" clip_to_extent="1" force_rhr="0" name="1">
+        <layer pass="1" enabled="1" class="SimpleLine" locked="1">
           <prop k="capstyle" v="square"/>
-          <prop k="color" v="0,0,0,255"/>
           <prop k="customdash" v="5;2"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="customdash_unit" v="MM"/>
+          <prop k="draw_inside_polygon" v="0"/>
           <prop k="joinstyle" v="bevel"/>
+          <prop k="line_color" v="0,0,0,255"/>
+          <prop k="line_style" v="solid"/>
+          <prop k="line_width" v="2"/>
+          <prop k="line_width_unit" v="MM"/>
           <prop k="offset" v="0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="offset_unit" v="MM"/>
-          <prop k="penstyle" v="solid"/>
+          <prop k="ring_filter" v="0"/>
           <prop k="use_custom_dash" v="0"/>
-          <prop k="width" v="1"/>
-          <prop k="width_unit" v="MM"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
         </layer>
-        <layer pass="1" class="SimpleLine" locked="1">
+        <layer pass="2" enabled="1" class="SimpleLine" locked="0">
           <prop k="capstyle" v="square"/>
-          <prop k="color" v="255,255,255,255"/>
           <prop k="customdash" v="5;2"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="customdash_unit" v="MM"/>
+          <prop k="draw_inside_polygon" v="0"/>
           <prop k="joinstyle" v="bevel"/>
+          <prop k="line_color" v="255,222,155,255"/>
+          <prop k="line_style" v="solid"/>
+          <prop k="line_width" v="1.2"/>
+          <prop k="line_width_unit" v="MM"/>
           <prop k="offset" v="0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="offset_unit" v="MM"/>
-          <prop k="penstyle" v="solid"/>
+          <prop k="ring_filter" v="0"/>
           <prop k="use_custom_dash" v="0"/>
-          <prop k="width" v="0.666667"/>
-          <prop k="width_unit" v="MM"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol alpha="1" type="line" clip_to_extent="1" force_rhr="0" name="2">
+        <layer pass="0" enabled="1" class="SimpleLine" locked="0">
+          <prop k="capstyle" v="square"/>
+          <prop k="customdash" v="5;2"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="customdash_unit" v="MM"/>
+          <prop k="draw_inside_polygon" v="0"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="line_color" v="0,0,0,255"/>
+          <prop k="line_style" v="solid"/>
+          <prop k="line_width" v="1"/>
+          <prop k="line_width_unit" v="MM"/>
+          <prop k="offset" v="0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="ring_filter" v="0"/>
+          <prop k="use_custom_dash" v="0"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+        <layer pass="1" enabled="1" class="SimpleLine" locked="1">
+          <prop k="capstyle" v="square"/>
+          <prop k="customdash" v="5;2"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="customdash_unit" v="MM"/>
+          <prop k="draw_inside_polygon" v="0"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="line_color" v="255,255,255,255"/>
+          <prop k="line_style" v="solid"/>
+          <prop k="line_width" v="0.666667"/>
+          <prop k="line_width_unit" v="MM"/>
+          <prop k="offset" v="0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="ring_filter" v="0"/>
+          <prop k="use_custom_dash" v="0"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
         </layer>
       </symbol>
     </symbols>
     <source-symbol>
-      <symbol alpha="1" type="line" name="0">
-        <layer pass="0" class="SimpleLine" locked="1">
+      <symbol alpha="1" type="line" clip_to_extent="1" force_rhr="0" name="0">
+        <layer pass="0" enabled="1" class="SimpleLine" locked="1">
           <prop k="capstyle" v="square"/>
-          <prop k="color" v="0,0,0,255"/>
           <prop k="customdash" v="5;2"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="customdash_unit" v="MM"/>
+          <prop k="draw_inside_polygon" v="0"/>
           <prop k="joinstyle" v="bevel"/>
+          <prop k="line_color" v="0,0,0,255"/>
+          <prop k="line_style" v="solid"/>
+          <prop k="line_width" v="5"/>
+          <prop k="line_width_unit" v="MM"/>
           <prop k="offset" v="0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="offset_unit" v="MM"/>
-          <prop k="penstyle" v="solid"/>
+          <prop k="ring_filter" v="0"/>
           <prop k="use_custom_dash" v="0"/>
-          <prop k="width" v="5"/>
-          <prop k="width_unit" v="MM"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
         </layer>
-        <layer pass="0" class="SimpleLine" locked="0">
+        <layer pass="0" enabled="1" class="SimpleLine" locked="0">
           <prop k="capstyle" v="square"/>
-          <prop k="color" v="255,255,0,255"/>
           <prop k="customdash" v="5;2"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="customdash_unit" v="MM"/>
+          <prop k="draw_inside_polygon" v="0"/>
           <prop k="joinstyle" v="bevel"/>
+          <prop k="line_color" v="255,255,0,255"/>
+          <prop k="line_style" v="solid"/>
+          <prop k="line_width" v="3"/>
+          <prop k="line_width_unit" v="MM"/>
           <prop k="offset" v="0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="offset_unit" v="MM"/>
-          <prop k="penstyle" v="solid"/>
+          <prop k="ring_filter" v="0"/>
           <prop k="use_custom_dash" v="0"/>
-          <prop k="width" v="3"/>
-          <prop k="width_unit" v="MM"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
         </layer>
       </symbol>
     </source-symbol>
@@ -126,172 +227,903 @@
       <prop k="color1" v="0,0,255,255"/>
       <prop k="color2" v="207,205,255,255"/>
       <prop k="discrete" v="0"/>
+      <prop k="rampType" v="gradient"/>
     </colorramp>
-    <rotation field=""/>
-    <sizescale field="" scalemethod="area"/>
+    <rotation/>
+    <sizescale/>
   </renderer-v2>
   <customproperties>
-    <property key="labeling" value="pal"/>
-    <property key="labeling/addDirectionSymbol" value="false"/>
-    <property key="labeling/angleOffset" value="0"/>
-    <property key="labeling/blendMode" value="0"/>
-    <property key="labeling/bufferBlendMode" value="0"/>
-    <property key="labeling/bufferColorA" value="255"/>
-    <property key="labeling/bufferColorB" value="255"/>
-    <property key="labeling/bufferColorG" value="255"/>
-    <property key="labeling/bufferColorR" value="255"/>
-    <property key="labeling/bufferDraw" value="false"/>
-    <property key="labeling/bufferJoinStyle" value="64"/>
-    <property key="labeling/bufferNoFill" value="false"/>
-    <property key="labeling/bufferSize" value="1"/>
-    <property key="labeling/bufferSizeInMapUnits" value="false"/>
-    <property key="labeling/bufferTransp" value="0"/>
-    <property key="labeling/centroidWhole" value="false"/>
-    <property key="labeling/decimals" value="3"/>
-    <property key="labeling/displayAll" value="false"/>
-    <property key="labeling/dist" value="0"/>
-    <property key="labeling/distInMapUnits" value="false"/>
-    <property key="labeling/enabled" value="false"/>
-    <property key="labeling/fieldName" value=""/>
-    <property key="labeling/fontBold" value="false"/>
-    <property key="labeling/fontCapitals" value="0"/>
-    <property key="labeling/fontFamily" value=".Lucida Grande UI"/>
-    <property key="labeling/fontItalic" value="false"/>
-    <property key="labeling/fontLetterSpacing" value="0"/>
-    <property key="labeling/fontLimitPixelSize" value="false"/>
-    <property key="labeling/fontMaxPixelSize" value="10000"/>
-    <property key="labeling/fontMinPixelSize" value="3"/>
-    <property key="labeling/fontSize" value="13"/>
-    <property key="labeling/fontSizeInMapUnits" value="false"/>
-    <property key="labeling/fontStrikeout" value="false"/>
-    <property key="labeling/fontUnderline" value="false"/>
-    <property key="labeling/fontWeight" value="50"/>
-    <property key="labeling/fontWordSpacing" value="0"/>
-    <property key="labeling/formatNumbers" value="false"/>
-    <property key="labeling/isExpression" value="false"/>
-    <property key="labeling/labelOffsetInMapUnits" value="true"/>
-    <property key="labeling/labelPerPart" value="false"/>
-    <property key="labeling/leftDirectionSymbol" value="&lt;"/>
-    <property key="labeling/limitNumLabels" value="false"/>
-    <property key="labeling/maxCurvedCharAngleIn" value="20"/>
-    <property key="labeling/maxCurvedCharAngleOut" value="-20"/>
-    <property key="labeling/maxNumLabels" value="2000"/>
-    <property key="labeling/mergeLines" value="false"/>
-    <property key="labeling/minFeatureSize" value="0"/>
-    <property key="labeling/multilineAlign" value="0"/>
-    <property key="labeling/multilineHeight" value="1"/>
-    <property key="labeling/namedStyle" value=""/>
-    <property key="labeling/obstacle" value="true"/>
-    <property key="labeling/placeDirectionSymbol" value="0"/>
-    <property key="labeling/placement" value="2"/>
-    <property key="labeling/placementFlags" value="10"/>
-    <property key="labeling/plussign" value="false"/>
-    <property key="labeling/preserveRotation" value="true"/>
-    <property key="labeling/previewBkgrdColor" value="#ffffff"/>
-    <property key="labeling/priority" value="5"/>
-    <property key="labeling/quadOffset" value="4"/>
-    <property key="labeling/reverseDirectionSymbol" value="false"/>
-    <property key="labeling/rightDirectionSymbol" value=">"/>
-    <property key="labeling/scaleMax" value="10000000"/>
-    <property key="labeling/scaleMin" value="1"/>
-    <property key="labeling/scaleVisibility" value="false"/>
-    <property key="labeling/shadowBlendMode" value="6"/>
-    <property key="labeling/shadowColorB" value="0"/>
-    <property key="labeling/shadowColorG" value="0"/>
-    <property key="labeling/shadowColorR" value="0"/>
-    <property key="labeling/shadowDraw" value="false"/>
-    <property key="labeling/shadowOffsetAngle" value="135"/>
-    <property key="labeling/shadowOffsetDist" value="1"/>
-    <property key="labeling/shadowOffsetGlobal" value="true"/>
-    <property key="labeling/shadowOffsetUnits" value="1"/>
-    <property key="labeling/shadowRadius" value="1.5"/>
-    <property key="labeling/shadowRadiusAlphaOnly" value="false"/>
-    <property key="labeling/shadowRadiusUnits" value="1"/>
-    <property key="labeling/shadowScale" value="100"/>
-    <property key="labeling/shadowTransparency" value="30"/>
-    <property key="labeling/shadowUnder" value="0"/>
-    <property key="labeling/shapeBlendMode" value="0"/>
-    <property key="labeling/shapeBorderColorA" value="255"/>
-    <property key="labeling/shapeBorderColorB" value="128"/>
-    <property key="labeling/shapeBorderColorG" value="128"/>
-    <property key="labeling/shapeBorderColorR" value="128"/>
-    <property key="labeling/shapeBorderWidth" value="0"/>
-    <property key="labeling/shapeBorderWidthUnits" value="1"/>
-    <property key="labeling/shapeDraw" value="false"/>
-    <property key="labeling/shapeFillColorA" value="255"/>
-    <property key="labeling/shapeFillColorB" value="255"/>
-    <property key="labeling/shapeFillColorG" value="255"/>
-    <property key="labeling/shapeFillColorR" value="255"/>
-    <property key="labeling/shapeJoinStyle" value="64"/>
-    <property key="labeling/shapeOffsetUnits" value="1"/>
-    <property key="labeling/shapeOffsetX" value="0"/>
-    <property key="labeling/shapeOffsetY" value="0"/>
-    <property key="labeling/shapeRadiiUnits" value="1"/>
-    <property key="labeling/shapeRadiiX" value="0"/>
-    <property key="labeling/shapeRadiiY" value="0"/>
-    <property key="labeling/shapeRotation" value="0"/>
-    <property key="labeling/shapeRotationType" value="0"/>
-    <property key="labeling/shapeSVGFile" value=""/>
-    <property key="labeling/shapeSizeType" value="0"/>
-    <property key="labeling/shapeSizeUnits" value="1"/>
-    <property key="labeling/shapeSizeX" value="0"/>
-    <property key="labeling/shapeSizeY" value="0"/>
-    <property key="labeling/shapeTransparency" value="0"/>
-    <property key="labeling/shapeType" value="0"/>
-    <property key="labeling/textColorA" value="255"/>
-    <property key="labeling/textColorB" value="0"/>
-    <property key="labeling/textColorG" value="0"/>
-    <property key="labeling/textColorR" value="0"/>
-    <property key="labeling/textTransp" value="0"/>
-    <property key="labeling/upsidedownLabels" value="0"/>
-    <property key="labeling/wrapChar" value=""/>
-    <property key="labeling/xOffset" value="0"/>
-    <property key="labeling/yOffset" value="0"/>
+    <property value="0" key="embeddedWidgets/count"/>
+    <property key="variableNames"/>
+    <property key="variableValues"/>
   </customproperties>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
-  <layerTransparency>0</layerTransparency>
-  <displayfield>TYPE</displayfield>
-  <label>0</label>
-  <labelattributes>
-    <label fieldname="" text="Label"/>
-    <family fieldname="" name="Ubuntu"/>
-    <size fieldname="" units="pt" value="12"/>
-    <bold fieldname="" on="0"/>
-    <italic fieldname="" on="0"/>
-    <underline fieldname="" on="0"/>
-    <strikeout fieldname="" on="0"/>
-    <color fieldname="" red="0" blue="0" green="0"/>
-    <x fieldname=""/>
-    <y fieldname=""/>
-    <offset x="0" y="0" units="pt" yfieldname="" xfieldname=""/>
-    <angle fieldname="" value="0" auto="0"/>
-    <alignment fieldname="" value="center"/>
-    <buffercolor fieldname="" red="255" blue="255" green="255"/>
-    <buffersize fieldname="" units="pt" value="1"/>
-    <bufferenabled fieldname="" on=""/>
-    <multilineenabled fieldname="" on=""/>
-    <selectedonly on=""/>
-  </labelattributes>
-  <edittypes>
-    <edittype labelontop="0" editable="1" type="0" name="LANES"/>
-    <edittype labelontop="0" editable="1" type="0" name="NAME"/>
-    <edittype labelontop="0" editable="1" type="0" name="ONEWAY"/>
-    <edittype labelontop="0" editable="1" type="0" name="TYPE"/>
-    <edittype labelontop="0" editable="1" type="0" name="aerialway"/>
-    <edittype labelontop="0" editable="1" type="0" name="barrier"/>
-    <edittype labelontop="0" editable="1" type="0" name="highway"/>
-    <edittype labelontop="0" editable="1" type="0" name="man_made"/>
-    <edittype labelontop="0" editable="1" type="0" name="name"/>
-    <edittype labelontop="0" editable="1" type="0" name="osm_id"/>
-    <edittype labelontop="0" editable="1" type="0" name="other_tags"/>
-    <edittype labelontop="0" editable="1" type="0" name="waterway"/>
-  </edittypes>
-  <editform></editform>
-  <editforminit></editforminit>
-  <annotationform></annotationform>
-  <editorlayout>generatedlayout</editorlayout>
+  <layerOpacity>1</layerOpacity>
+  <SingleCategoryDiagramRenderer diagramType="Histogram" attributeLegend="1">
+    <DiagramCategory height="15" penWidth="0" lineSizeScale="3x:0,0,0,0,0,0" lineSizeType="MM" backgroundAlpha="255" minimumSize="0" penAlpha="255" sizeScale="3x:0,0,0,0,0,0" width="15" diagramOrientation="Up" scaleBasedVisibility="0" sizeType="MM" scaleDependency="Area" maxScaleDenominator="1e+8" rotationOffset="270" penColor="#000000" minScaleDenominator="-4.65661e-10" barWidth="5" enabled="0" opacity="1" labelPlacementMethod="XHeight" backgroundColor="#ffffff">
+      <fontProperties description="Ubuntu,11,-1,5,50,0,0,0,0,0" style=""/>
+    </DiagramCategory>
+  </SingleCategoryDiagramRenderer>
+  <DiagramLayerSettings zIndex="0" priority="0" obstacle="0" placement="2" dist="0" showAll="1" linePlacementFlags="18">
+    <properties>
+      <Option type="Map">
+        <Option value="" type="QString" name="name"/>
+        <Option name="properties"/>
+        <Option value="collection" type="QString" name="type"/>
+      </Option>
+    </properties>
+  </DiagramLayerSettings>
+  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+    <activeChecks/>
+    <checkConfiguration/>
+  </geometryOptions>
+  <fieldConfiguration>
+    <field name="fid">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="full_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="osm_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="osm_type">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="highway">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="lanes">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="maxspeed">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="oneway">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="ref">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="surface">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="name">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="embankment">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="maxweight">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="destination:backward">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="destination:forward">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="destination:ref:backward">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="destination:symbol:forward">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="cutting">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="access">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="hgv">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="foot">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="sac_scale">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="name:af">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="lanes:backward">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="lanes:forward">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="reg_ref">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="bicycle">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="cycleway">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="sidewalk">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="service">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="bridge">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="layer">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="tracktype">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="trail_visibility">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="wheelchair">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="horse">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="ski">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="snowmobile">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="motor_vehicle">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="source:name">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="name:en">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="start_date">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="tunnel">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="official_ref">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="placement">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="shoulder">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="smoothness">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="turn:lanes">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="change:lanes">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="destination">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="destination:ref">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="placement:end">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="placement:start">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="destination:symbol">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="alt_name">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="covered">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="turn:lanes:forward">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="turn:lanes:backward">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+  </fieldConfiguration>
+  <aliases>
+    <alias index="0" field="fid" name=""/>
+    <alias index="1" field="full_id" name=""/>
+    <alias index="2" field="osm_id" name=""/>
+    <alias index="3" field="osm_type" name=""/>
+    <alias index="4" field="highway" name=""/>
+    <alias index="5" field="lanes" name=""/>
+    <alias index="6" field="maxspeed" name=""/>
+    <alias index="7" field="oneway" name=""/>
+    <alias index="8" field="ref" name=""/>
+    <alias index="9" field="surface" name=""/>
+    <alias index="10" field="name" name=""/>
+    <alias index="11" field="embankment" name=""/>
+    <alias index="12" field="maxweight" name=""/>
+    <alias index="13" field="destination:backward" name=""/>
+    <alias index="14" field="destination:forward" name=""/>
+    <alias index="15" field="destination:ref:backward" name=""/>
+    <alias index="16" field="destination:symbol:forward" name=""/>
+    <alias index="17" field="cutting" name=""/>
+    <alias index="18" field="access" name=""/>
+    <alias index="19" field="hgv" name=""/>
+    <alias index="20" field="foot" name=""/>
+    <alias index="21" field="sac_scale" name=""/>
+    <alias index="22" field="name:af" name=""/>
+    <alias index="23" field="lanes:backward" name=""/>
+    <alias index="24" field="lanes:forward" name=""/>
+    <alias index="25" field="reg_ref" name=""/>
+    <alias index="26" field="bicycle" name=""/>
+    <alias index="27" field="cycleway" name=""/>
+    <alias index="28" field="sidewalk" name=""/>
+    <alias index="29" field="service" name=""/>
+    <alias index="30" field="bridge" name=""/>
+    <alias index="31" field="layer" name=""/>
+    <alias index="32" field="tracktype" name=""/>
+    <alias index="33" field="trail_visibility" name=""/>
+    <alias index="34" field="wheelchair" name=""/>
+    <alias index="35" field="horse" name=""/>
+    <alias index="36" field="ski" name=""/>
+    <alias index="37" field="snowmobile" name=""/>
+    <alias index="38" field="motor_vehicle" name=""/>
+    <alias index="39" field="source:name" name=""/>
+    <alias index="40" field="name:en" name=""/>
+    <alias index="41" field="start_date" name=""/>
+    <alias index="42" field="tunnel" name=""/>
+    <alias index="43" field="official_ref" name=""/>
+    <alias index="44" field="placement" name=""/>
+    <alias index="45" field="shoulder" name=""/>
+    <alias index="46" field="smoothness" name=""/>
+    <alias index="47" field="turn:lanes" name=""/>
+    <alias index="48" field="change:lanes" name=""/>
+    <alias index="49" field="destination" name=""/>
+    <alias index="50" field="destination:ref" name=""/>
+    <alias index="51" field="placement:end" name=""/>
+    <alias index="52" field="placement:start" name=""/>
+    <alias index="53" field="destination:symbol" name=""/>
+    <alias index="54" field="alt_name" name=""/>
+    <alias index="55" field="covered" name=""/>
+    <alias index="56" field="turn:lanes:forward" name=""/>
+    <alias index="57" field="turn:lanes:backward" name=""/>
+  </aliases>
   <excludeAttributesWMS/>
   <excludeAttributesWFS/>
-  <attributeactions/>
+  <defaults>
+    <default applyOnUpdate="0" field="fid" expression=""/>
+    <default applyOnUpdate="0" field="full_id" expression=""/>
+    <default applyOnUpdate="0" field="osm_id" expression=""/>
+    <default applyOnUpdate="0" field="osm_type" expression=""/>
+    <default applyOnUpdate="0" field="highway" expression=""/>
+    <default applyOnUpdate="0" field="lanes" expression=""/>
+    <default applyOnUpdate="0" field="maxspeed" expression=""/>
+    <default applyOnUpdate="0" field="oneway" expression=""/>
+    <default applyOnUpdate="0" field="ref" expression=""/>
+    <default applyOnUpdate="0" field="surface" expression=""/>
+    <default applyOnUpdate="0" field="name" expression=""/>
+    <default applyOnUpdate="0" field="embankment" expression=""/>
+    <default applyOnUpdate="0" field="maxweight" expression=""/>
+    <default applyOnUpdate="0" field="destination:backward" expression=""/>
+    <default applyOnUpdate="0" field="destination:forward" expression=""/>
+    <default applyOnUpdate="0" field="destination:ref:backward" expression=""/>
+    <default applyOnUpdate="0" field="destination:symbol:forward" expression=""/>
+    <default applyOnUpdate="0" field="cutting" expression=""/>
+    <default applyOnUpdate="0" field="access" expression=""/>
+    <default applyOnUpdate="0" field="hgv" expression=""/>
+    <default applyOnUpdate="0" field="foot" expression=""/>
+    <default applyOnUpdate="0" field="sac_scale" expression=""/>
+    <default applyOnUpdate="0" field="name:af" expression=""/>
+    <default applyOnUpdate="0" field="lanes:backward" expression=""/>
+    <default applyOnUpdate="0" field="lanes:forward" expression=""/>
+    <default applyOnUpdate="0" field="reg_ref" expression=""/>
+    <default applyOnUpdate="0" field="bicycle" expression=""/>
+    <default applyOnUpdate="0" field="cycleway" expression=""/>
+    <default applyOnUpdate="0" field="sidewalk" expression=""/>
+    <default applyOnUpdate="0" field="service" expression=""/>
+    <default applyOnUpdate="0" field="bridge" expression=""/>
+    <default applyOnUpdate="0" field="layer" expression=""/>
+    <default applyOnUpdate="0" field="tracktype" expression=""/>
+    <default applyOnUpdate="0" field="trail_visibility" expression=""/>
+    <default applyOnUpdate="0" field="wheelchair" expression=""/>
+    <default applyOnUpdate="0" field="horse" expression=""/>
+    <default applyOnUpdate="0" field="ski" expression=""/>
+    <default applyOnUpdate="0" field="snowmobile" expression=""/>
+    <default applyOnUpdate="0" field="motor_vehicle" expression=""/>
+    <default applyOnUpdate="0" field="source:name" expression=""/>
+    <default applyOnUpdate="0" field="name:en" expression=""/>
+    <default applyOnUpdate="0" field="start_date" expression=""/>
+    <default applyOnUpdate="0" field="tunnel" expression=""/>
+    <default applyOnUpdate="0" field="official_ref" expression=""/>
+    <default applyOnUpdate="0" field="placement" expression=""/>
+    <default applyOnUpdate="0" field="shoulder" expression=""/>
+    <default applyOnUpdate="0" field="smoothness" expression=""/>
+    <default applyOnUpdate="0" field="turn:lanes" expression=""/>
+    <default applyOnUpdate="0" field="change:lanes" expression=""/>
+    <default applyOnUpdate="0" field="destination" expression=""/>
+    <default applyOnUpdate="0" field="destination:ref" expression=""/>
+    <default applyOnUpdate="0" field="placement:end" expression=""/>
+    <default applyOnUpdate="0" field="placement:start" expression=""/>
+    <default applyOnUpdate="0" field="destination:symbol" expression=""/>
+    <default applyOnUpdate="0" field="alt_name" expression=""/>
+    <default applyOnUpdate="0" field="covered" expression=""/>
+    <default applyOnUpdate="0" field="turn:lanes:forward" expression=""/>
+    <default applyOnUpdate="0" field="turn:lanes:backward" expression=""/>
+  </defaults>
+  <constraints>
+    <constraint constraints="3" notnull_strength="1" exp_strength="0" field="fid" unique_strength="1"/>
+    <constraint constraints="0" notnull_strength="0" exp_strength="0" field="full_id" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" exp_strength="0" field="osm_id" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" exp_strength="0" field="osm_type" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" exp_strength="0" field="highway" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" exp_strength="0" field="lanes" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" exp_strength="0" field="maxspeed" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" exp_strength="0" field="oneway" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" exp_strength="0" field="ref" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" exp_strength="0" field="surface" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" exp_strength="0" field="name" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" exp_strength="0" field="embankment" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" exp_strength="0" field="maxweight" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" exp_strength="0" field="destination:backward" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" exp_strength="0" field="destination:forward" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" exp_strength="0" field="destination:ref:backward" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" exp_strength="0" field="destination:symbol:forward" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" exp_strength="0" field="cutting" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" exp_strength="0" field="access" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" exp_strength="0" field="hgv" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" exp_strength="0" field="foot" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" exp_strength="0" field="sac_scale" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" exp_strength="0" field="name:af" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" exp_strength="0" field="lanes:backward" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" exp_strength="0" field="lanes:forward" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" exp_strength="0" field="reg_ref" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" exp_strength="0" field="bicycle" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" exp_strength="0" field="cycleway" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" exp_strength="0" field="sidewalk" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" exp_strength="0" field="service" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" exp_strength="0" field="bridge" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" exp_strength="0" field="layer" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" exp_strength="0" field="tracktype" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" exp_strength="0" field="trail_visibility" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" exp_strength="0" field="wheelchair" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" exp_strength="0" field="horse" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" exp_strength="0" field="ski" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" exp_strength="0" field="snowmobile" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" exp_strength="0" field="motor_vehicle" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" exp_strength="0" field="source:name" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" exp_strength="0" field="name:en" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" exp_strength="0" field="start_date" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" exp_strength="0" field="tunnel" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" exp_strength="0" field="official_ref" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" exp_strength="0" field="placement" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" exp_strength="0" field="shoulder" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" exp_strength="0" field="smoothness" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" exp_strength="0" field="turn:lanes" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" exp_strength="0" field="change:lanes" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" exp_strength="0" field="destination" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" exp_strength="0" field="destination:ref" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" exp_strength="0" field="placement:end" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" exp_strength="0" field="placement:start" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" exp_strength="0" field="destination:symbol" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" exp_strength="0" field="alt_name" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" exp_strength="0" field="covered" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" exp_strength="0" field="turn:lanes:forward" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" exp_strength="0" field="turn:lanes:backward" unique_strength="0"/>
+  </constraints>
+  <constraintExpressions>
+    <constraint field="fid" exp="" desc=""/>
+    <constraint field="full_id" exp="" desc=""/>
+    <constraint field="osm_id" exp="" desc=""/>
+    <constraint field="osm_type" exp="" desc=""/>
+    <constraint field="highway" exp="" desc=""/>
+    <constraint field="lanes" exp="" desc=""/>
+    <constraint field="maxspeed" exp="" desc=""/>
+    <constraint field="oneway" exp="" desc=""/>
+    <constraint field="ref" exp="" desc=""/>
+    <constraint field="surface" exp="" desc=""/>
+    <constraint field="name" exp="" desc=""/>
+    <constraint field="embankment" exp="" desc=""/>
+    <constraint field="maxweight" exp="" desc=""/>
+    <constraint field="destination:backward" exp="" desc=""/>
+    <constraint field="destination:forward" exp="" desc=""/>
+    <constraint field="destination:ref:backward" exp="" desc=""/>
+    <constraint field="destination:symbol:forward" exp="" desc=""/>
+    <constraint field="cutting" exp="" desc=""/>
+    <constraint field="access" exp="" desc=""/>
+    <constraint field="hgv" exp="" desc=""/>
+    <constraint field="foot" exp="" desc=""/>
+    <constraint field="sac_scale" exp="" desc=""/>
+    <constraint field="name:af" exp="" desc=""/>
+    <constraint field="lanes:backward" exp="" desc=""/>
+    <constraint field="lanes:forward" exp="" desc=""/>
+    <constraint field="reg_ref" exp="" desc=""/>
+    <constraint field="bicycle" exp="" desc=""/>
+    <constraint field="cycleway" exp="" desc=""/>
+    <constraint field="sidewalk" exp="" desc=""/>
+    <constraint field="service" exp="" desc=""/>
+    <constraint field="bridge" exp="" desc=""/>
+    <constraint field="layer" exp="" desc=""/>
+    <constraint field="tracktype" exp="" desc=""/>
+    <constraint field="trail_visibility" exp="" desc=""/>
+    <constraint field="wheelchair" exp="" desc=""/>
+    <constraint field="horse" exp="" desc=""/>
+    <constraint field="ski" exp="" desc=""/>
+    <constraint field="snowmobile" exp="" desc=""/>
+    <constraint field="motor_vehicle" exp="" desc=""/>
+    <constraint field="source:name" exp="" desc=""/>
+    <constraint field="name:en" exp="" desc=""/>
+    <constraint field="start_date" exp="" desc=""/>
+    <constraint field="tunnel" exp="" desc=""/>
+    <constraint field="official_ref" exp="" desc=""/>
+    <constraint field="placement" exp="" desc=""/>
+    <constraint field="shoulder" exp="" desc=""/>
+    <constraint field="smoothness" exp="" desc=""/>
+    <constraint field="turn:lanes" exp="" desc=""/>
+    <constraint field="change:lanes" exp="" desc=""/>
+    <constraint field="destination" exp="" desc=""/>
+    <constraint field="destination:ref" exp="" desc=""/>
+    <constraint field="placement:end" exp="" desc=""/>
+    <constraint field="placement:start" exp="" desc=""/>
+    <constraint field="destination:symbol" exp="" desc=""/>
+    <constraint field="alt_name" exp="" desc=""/>
+    <constraint field="covered" exp="" desc=""/>
+    <constraint field="turn:lanes:forward" exp="" desc=""/>
+    <constraint field="turn:lanes:backward" exp="" desc=""/>
+  </constraintExpressions>
+  <expressionfields/>
+  <attributeactions>
+    <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+  </attributeactions>
+  <attributetableconfig sortExpression="" actionWidgetStyle="dropDown" sortOrder="0">
+    <columns>
+      <column hidden="0" type="field" width="-1" name="fid"/>
+      <column hidden="0" type="field" width="-1" name="full_id"/>
+      <column hidden="0" type="field" width="-1" name="osm_id"/>
+      <column hidden="0" type="field" width="-1" name="osm_type"/>
+      <column hidden="0" type="field" width="-1" name="highway"/>
+      <column hidden="0" type="field" width="-1" name="lanes"/>
+      <column hidden="0" type="field" width="-1" name="maxspeed"/>
+      <column hidden="0" type="field" width="-1" name="oneway"/>
+      <column hidden="0" type="field" width="-1" name="ref"/>
+      <column hidden="0" type="field" width="-1" name="surface"/>
+      <column hidden="0" type="field" width="-1" name="name"/>
+      <column hidden="0" type="field" width="-1" name="embankment"/>
+      <column hidden="0" type="field" width="-1" name="maxweight"/>
+      <column hidden="0" type="field" width="-1" name="destination:backward"/>
+      <column hidden="0" type="field" width="-1" name="destination:forward"/>
+      <column hidden="0" type="field" width="-1" name="destination:ref:backward"/>
+      <column hidden="0" type="field" width="-1" name="destination:symbol:forward"/>
+      <column hidden="0" type="field" width="-1" name="cutting"/>
+      <column hidden="0" type="field" width="-1" name="access"/>
+      <column hidden="0" type="field" width="-1" name="hgv"/>
+      <column hidden="0" type="field" width="-1" name="foot"/>
+      <column hidden="0" type="field" width="-1" name="sac_scale"/>
+      <column hidden="0" type="field" width="-1" name="name:af"/>
+      <column hidden="0" type="field" width="-1" name="lanes:backward"/>
+      <column hidden="0" type="field" width="-1" name="lanes:forward"/>
+      <column hidden="0" type="field" width="-1" name="reg_ref"/>
+      <column hidden="0" type="field" width="-1" name="bicycle"/>
+      <column hidden="0" type="field" width="-1" name="cycleway"/>
+      <column hidden="0" type="field" width="-1" name="sidewalk"/>
+      <column hidden="0" type="field" width="-1" name="service"/>
+      <column hidden="0" type="field" width="-1" name="bridge"/>
+      <column hidden="0" type="field" width="-1" name="layer"/>
+      <column hidden="0" type="field" width="-1" name="tracktype"/>
+      <column hidden="0" type="field" width="-1" name="trail_visibility"/>
+      <column hidden="0" type="field" width="-1" name="wheelchair"/>
+      <column hidden="0" type="field" width="-1" name="horse"/>
+      <column hidden="0" type="field" width="-1" name="ski"/>
+      <column hidden="0" type="field" width="-1" name="snowmobile"/>
+      <column hidden="0" type="field" width="-1" name="motor_vehicle"/>
+      <column hidden="0" type="field" width="-1" name="source:name"/>
+      <column hidden="0" type="field" width="-1" name="name:en"/>
+      <column hidden="0" type="field" width="-1" name="start_date"/>
+      <column hidden="0" type="field" width="-1" name="tunnel"/>
+      <column hidden="0" type="field" width="-1" name="official_ref"/>
+      <column hidden="0" type="field" width="-1" name="placement"/>
+      <column hidden="0" type="field" width="-1" name="shoulder"/>
+      <column hidden="0" type="field" width="-1" name="smoothness"/>
+      <column hidden="0" type="field" width="-1" name="turn:lanes"/>
+      <column hidden="0" type="field" width="-1" name="change:lanes"/>
+      <column hidden="0" type="field" width="-1" name="destination"/>
+      <column hidden="0" type="field" width="-1" name="destination:ref"/>
+      <column hidden="0" type="field" width="-1" name="placement:end"/>
+      <column hidden="0" type="field" width="-1" name="placement:start"/>
+      <column hidden="0" type="field" width="-1" name="destination:symbol"/>
+      <column hidden="0" type="field" width="-1" name="alt_name"/>
+      <column hidden="0" type="field" width="-1" name="covered"/>
+      <column hidden="0" type="field" width="-1" name="turn:lanes:forward"/>
+      <column hidden="0" type="field" width="-1" name="turn:lanes:backward"/>
+      <column hidden="1" type="actions" width="-1"/>
+    </columns>
+  </attributetableconfig>
+  <conditionalstyles>
+    <rowstyles/>
+    <fieldstyles/>
+  </conditionalstyles>
+  <editform tolerant="1"></editform>
+  <editforminit/>
+  <editforminitcodesource>0</editforminitcodesource>
+  <editforminitfilepath></editforminitfilepath>
+  <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+"""
+QGIS forms can have a Python function that is called when the form is
+opened.
+
+Use this function to add extra logic to your forms.
+
+Enter the name of the function in the "Python Init function"
+field.
+An example follows:
+"""
+from qgis.PyQt.QtWidgets import QWidget
+
+def my_form_open(dialog, layer, feature):
+	geom = feature.geometry()
+	control = dialog.findChild(QWidget, "MyLineEdit")
+]]></editforminitcode>
+  <featformsuppress>0</featformsuppress>
+  <editorlayout>generatedlayout</editorlayout>
+  <editable>
+    <field editable="1" name="access"/>
+    <field editable="1" name="alt_name"/>
+    <field editable="1" name="bicycle"/>
+    <field editable="1" name="bridge"/>
+    <field editable="1" name="change:lanes"/>
+    <field editable="1" name="covered"/>
+    <field editable="1" name="cutting"/>
+    <field editable="1" name="cycleway"/>
+    <field editable="1" name="destination"/>
+    <field editable="1" name="destination:backward"/>
+    <field editable="1" name="destination:forward"/>
+    <field editable="1" name="destination:ref"/>
+    <field editable="1" name="destination:ref:backward"/>
+    <field editable="1" name="destination:symbol"/>
+    <field editable="1" name="destination:symbol:forward"/>
+    <field editable="1" name="embankment"/>
+    <field editable="1" name="fid"/>
+    <field editable="1" name="foot"/>
+    <field editable="1" name="full_id"/>
+    <field editable="1" name="hgv"/>
+    <field editable="1" name="highway"/>
+    <field editable="1" name="horse"/>
+    <field editable="1" name="lanes"/>
+    <field editable="1" name="lanes:backward"/>
+    <field editable="1" name="lanes:forward"/>
+    <field editable="1" name="layer"/>
+    <field editable="1" name="maxspeed"/>
+    <field editable="1" name="maxweight"/>
+    <field editable="1" name="motor_vehicle"/>
+    <field editable="1" name="name"/>
+    <field editable="1" name="name:af"/>
+    <field editable="1" name="name:en"/>
+    <field editable="1" name="official_ref"/>
+    <field editable="1" name="oneway"/>
+    <field editable="1" name="osm_id"/>
+    <field editable="1" name="osm_type"/>
+    <field editable="1" name="placement"/>
+    <field editable="1" name="placement:end"/>
+    <field editable="1" name="placement:start"/>
+    <field editable="1" name="ref"/>
+    <field editable="1" name="reg_ref"/>
+    <field editable="1" name="sac_scale"/>
+    <field editable="1" name="service"/>
+    <field editable="1" name="shoulder"/>
+    <field editable="1" name="sidewalk"/>
+    <field editable="1" name="ski"/>
+    <field editable="1" name="smoothness"/>
+    <field editable="1" name="snowmobile"/>
+    <field editable="1" name="source:name"/>
+    <field editable="1" name="start_date"/>
+    <field editable="1" name="surface"/>
+    <field editable="1" name="tracktype"/>
+    <field editable="1" name="trail_visibility"/>
+    <field editable="1" name="tunnel"/>
+    <field editable="1" name="turn:lanes"/>
+    <field editable="1" name="turn:lanes:backward"/>
+    <field editable="1" name="turn:lanes:forward"/>
+    <field editable="1" name="wheelchair"/>
+  </editable>
+  <labelOnTop>
+    <field labelOnTop="0" name="access"/>
+    <field labelOnTop="0" name="alt_name"/>
+    <field labelOnTop="0" name="bicycle"/>
+    <field labelOnTop="0" name="bridge"/>
+    <field labelOnTop="0" name="change:lanes"/>
+    <field labelOnTop="0" name="covered"/>
+    <field labelOnTop="0" name="cutting"/>
+    <field labelOnTop="0" name="cycleway"/>
+    <field labelOnTop="0" name="destination"/>
+    <field labelOnTop="0" name="destination:backward"/>
+    <field labelOnTop="0" name="destination:forward"/>
+    <field labelOnTop="0" name="destination:ref"/>
+    <field labelOnTop="0" name="destination:ref:backward"/>
+    <field labelOnTop="0" name="destination:symbol"/>
+    <field labelOnTop="0" name="destination:symbol:forward"/>
+    <field labelOnTop="0" name="embankment"/>
+    <field labelOnTop="0" name="fid"/>
+    <field labelOnTop="0" name="foot"/>
+    <field labelOnTop="0" name="full_id"/>
+    <field labelOnTop="0" name="hgv"/>
+    <field labelOnTop="0" name="highway"/>
+    <field labelOnTop="0" name="horse"/>
+    <field labelOnTop="0" name="lanes"/>
+    <field labelOnTop="0" name="lanes:backward"/>
+    <field labelOnTop="0" name="lanes:forward"/>
+    <field labelOnTop="0" name="layer"/>
+    <field labelOnTop="0" name="maxspeed"/>
+    <field labelOnTop="0" name="maxweight"/>
+    <field labelOnTop="0" name="motor_vehicle"/>
+    <field labelOnTop="0" name="name"/>
+    <field labelOnTop="0" name="name:af"/>
+    <field labelOnTop="0" name="name:en"/>
+    <field labelOnTop="0" name="official_ref"/>
+    <field labelOnTop="0" name="oneway"/>
+    <field labelOnTop="0" name="osm_id"/>
+    <field labelOnTop="0" name="osm_type"/>
+    <field labelOnTop="0" name="placement"/>
+    <field labelOnTop="0" name="placement:end"/>
+    <field labelOnTop="0" name="placement:start"/>
+    <field labelOnTop="0" name="ref"/>
+    <field labelOnTop="0" name="reg_ref"/>
+    <field labelOnTop="0" name="sac_scale"/>
+    <field labelOnTop="0" name="service"/>
+    <field labelOnTop="0" name="shoulder"/>
+    <field labelOnTop="0" name="sidewalk"/>
+    <field labelOnTop="0" name="ski"/>
+    <field labelOnTop="0" name="smoothness"/>
+    <field labelOnTop="0" name="snowmobile"/>
+    <field labelOnTop="0" name="source:name"/>
+    <field labelOnTop="0" name="start_date"/>
+    <field labelOnTop="0" name="surface"/>
+    <field labelOnTop="0" name="tracktype"/>
+    <field labelOnTop="0" name="trail_visibility"/>
+    <field labelOnTop="0" name="tunnel"/>
+    <field labelOnTop="0" name="turn:lanes"/>
+    <field labelOnTop="0" name="turn:lanes:backward"/>
+    <field labelOnTop="0" name="turn:lanes:forward"/>
+    <field labelOnTop="0" name="wheelchair"/>
+  </labelOnTop>
+  <widgets/>
+  <previewExpression>fid</previewExpression>
+  <mapTip>TYPE</mapTip>
+  <layerGeometryType>1</layerGeometryType>
 </qgis>


### PR DESCRIPTION
Replace the "unclassified" class in the [symbology](https://docs.qgis.org/testing/en/docs/training_manual/basic_map/symbology.html#hard-ty) with a NULL class as data with null value were missing in the current classification (hence not shown in the map canvas). Related to https://github.com/qgis/QGIS-Documentation/pull/3301